### PR TITLE
Fix bug where `//?` comments are converted to code in `#include`'d files.

### DIFF
--- a/src/Errors/ShaderCompiler.cs
+++ b/src/Errors/ShaderCompiler.cs
@@ -111,7 +111,6 @@ namespace DMS.GLSL.Errors
 				if (File.Exists(includeFileName))
 				{
 					var includeCode = File.ReadAllText(includeFileName);
-					includeCode = SpecialCommentReplacement(includeCode, "//!");
 
 					if (includedFiles.Contains(includeFileName))
 						return includeCode;
@@ -123,7 +122,8 @@ namespace DMS.GLSL.Errors
 			}
 
 			shaderCode = SpecialCommentReplacement(shaderCode, "//!");
-			shaderCode = SpecialCommentReplacement(shaderCode, "//?");
+			if (includedFiles.Count == 0)
+				shaderCode = SpecialCommentReplacement(shaderCode, "//?");
 			return Transformations.ExpandIncludes(shaderCode, GetIncludeCode);
 		}
 


### PR DESCRIPTION
Hello,

I just noticed I created this bug in my previous pull request for including files recursively. Since `ExpandedCode()` is called on every included file, it would always expand the `//?` comments. I added a check so that `//?` comments are expanded only when the `HashSet includedFiles` is empty. Which should only be the case for the root rile. Sorry for overlooking this!