### PR TITLE
Run external compile in Temp dir in case it needs to output files

### DIFF
--- a/src/Errors/ShaderCompiler.cs
+++ b/src/Errors/ShaderCompiler.cs
@@ -165,6 +165,7 @@ namespace DMS.GLSL.Errors
 				{
 					process.StartInfo.FileName = options.ExternalCompilerExeFilePath;
 					process.StartInfo.Arguments = $"{options.ExternalCompilerArguments} {shaderFileName}"; //arguments
+					process.StartInfo.WorkingDirectory = Path.GetTempPath();
 					process.StartInfo.UseShellExecute = false;
 					process.StartInfo.RedirectStandardOutput = true;
 					process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;


### PR DESCRIPTION
This makes "glslangValidator.exe -V" work. -V turns on Vulkan mode, but also turns on output of a resulting .spv file.