### PR TITLE
Fix external compiler not working

### DIFF
--- a/GLSL_Shared/Errors/ShaderCompiler.cs
+++ b/GLSL_Shared/Errors/ShaderCompiler.cs
@@ -181,7 +181,7 @@ namespace DMS.GLSL.Errors
 				{
 					process.StartInfo.FileName = VsExpand.EnvironmentVariables(settings.ExternalCompilerExeFilePath);
 					var arguments = VsExpand.EnvironmentVariables(settings.ExternalCompilerArguments);
-					process.StartInfo.Arguments = $"{arguments} {shaderFileName}"; //arguments
+					process.StartInfo.Arguments = $"{arguments} \"{shaderFileName}\""; //arguments
 					process.StartInfo.WorkingDirectory = tempPath;
 					process.StartInfo.UseShellExecute = false;
 					process.StartInfo.RedirectStandardOutput = true;


### PR DESCRIPTION
Quick fix for #91. Root cause seems to just be that the invoked arg string did not have the string literal portion escaped, so any path with a space in it would be incorrected interpreted.