### PR TITLE
Make ExpandIncludes optional

### DIFF
--- a/GLSL_Shared/Contracts/ICompilerSettings.cs
+++ b/GLSL_Shared/Contracts/ICompilerSettings.cs
@@ -6,6 +6,7 @@
 		string ExternalCompilerArguments { get; }
 		string ExternalCompilerExeFilePath { get; }
 		bool LiveCompiling { get; }
+		bool ExpandIncludes {  get; }
 		bool PrintShaderCompilerLog { get; }
 	}
 }

--- a/GLSL_Shared/Errors/ShaderCompiler.cs
+++ b/GLSL_Shared/Errors/ShaderCompiler.cs
@@ -104,7 +104,7 @@ namespace DMS.GLSL.Errors
 			}
 		}
 
-		private static string ExpandedCode(string shaderCode, string shaderFileDir, HashSet<string> includedFiles = null)
+		private string ExpandedCode(string shaderCode, string shaderFileDir, HashSet<string> includedFiles = null)
 		{
 			if (includedFiles is null)
 			{
@@ -149,7 +149,14 @@ namespace DMS.GLSL.Errors
 			{
 				shaderCode = SpecialCommentReplacement(shaderCode, "//?");
 			}
-			return GLSLhelper.Transformation.ExpandIncludes(shaderCode, GetIncludeCode);
+			if (settings.ExpandIncludes)
+			{
+				return GLSLhelper.Transformation.ExpandIncludes(shaderCode, GetIncludeCode);
+			}
+			else
+			{
+				return shaderCode;
+			}
 		}
 
 		private static string Compile(string shaderCode, string shaderContentType, ILogger logger, ICompilerSettings settings)

--- a/GLSL_Shared/Options/OptionPage.cs
+++ b/GLSL_Shared/Options/OptionPage.cs
@@ -28,6 +28,11 @@ namespace DMS.GLSL.Options
 		public bool LiveCompiling { get; set; } = true;
 
 		[Category("General")]
+		[DisplayName("Expand includes")]
+		[Description("Expand includes to support shader compilers which do not support the #include pragma. This option only works if include paths are absolute or relative to the current file")]
+		public bool ExpandIncludes { get; set; } = true;
+
+		[Category("General")]
 		[DisplayName("User key words 1")]
 		[Description("Space separated list of user key words (used for coloring)")]
 		public string UserKeyWords1


### PR DESCRIPTION
`GetIncludeCode` currently invalidates the shader source if an include is not found (see [here](https://github.com/danielscherzer/GLSL/blob/16601fd50b9bbf9724ed37c30ce923b08caebe09/GLSL_Shared/Errors/ShaderCompiler.cs#L144)). This pull request adds an option to disable the expansion of includes so that the shader compiler can resolve includes itself.

**Example options**
Expand includes: false
External shader compiler: %VULKAN_SDK%\Bin\glslc.exe
Shader compiler arguments: -I "/path/to/shader/includes"