### PR TITLE
support of variables %shaderDir% %shaderName% %shaderExt% in ExternalCompilerArguments

### DIFF
--- a/GLSL_Shared/Errors/SquiggleTaggerProvider.cs
+++ b/GLSL_Shared/Errors/SquiggleTaggerProvider.cs
@@ -47,7 +47,8 @@ namespace DMS.GLSL.Errors
 					//if not currently compiling then compile shader from changed text otherwise add to the "to be compiled" list
 					if (settings.LiveCompiling)
 					{
-						shaderCompiler.RequestCompile(shaderCode, shaderType, tagger.UpdateErrors, GetDocumentDir(buffer));
+						var filePath = GetFilePath(buffer);
+						shaderCompiler.RequestCompile(shaderCode, shaderType, tagger.UpdateErrors, Path.GetDirectoryName(filePath), Path.GetFileName(filePath));
 					}
 					else
 					{
@@ -67,12 +68,12 @@ namespace DMS.GLSL.Errors
 		private readonly ShaderCompiler shaderCompiler;
 		private readonly ICompilerSettings settings;
 
-		private static string GetDocumentDir(ITextBuffer textBuffer)
+		private static string GetFilePath(ITextBuffer textBuffer)
 		{
 			foreach (var prop in textBuffer.Properties.PropertyList)
 			{
 				if (!(prop.Value is ITextDocument doc)) continue;
-				return Path.GetDirectoryName(doc.FilePath);
+				return doc.FilePath;
 			}
 			return string.Empty;
 		}

--- a/GLSL_Shared/Errors/VsExpand.cs
+++ b/GLSL_Shared/Errors/VsExpand.cs
@@ -32,6 +32,14 @@ namespace DMS.GLSL.Errors
 			return joinableTaskFactory.Run(() => EnvironmentVariablesAsync(text));
 		}
 
+		public static string EnvironmentVariables(string text, string fileDir, string fileName)
+		{
+			var joinableTaskFactory = ThreadHelper.JoinableTaskFactory;
+			text = text.Replace("%shaderDir%", fileDir)
+				.Replace("%shaderName%", Path.GetFileNameWithoutExtension(fileName))
+				.Replace("%shaderExt%", Path.GetExtension(fileName));
+			return joinableTaskFactory.Run(() => EnvironmentVariablesAsync(text));
+		}
 		private static readonly object _syncRoot = new object();
 	}
 }


### PR DESCRIPTION
Missing the ability to give different names to compiled shaders in ExternalCompilerArguments
